### PR TITLE
Fix macro renaming issue and some compiler warnings

### DIFF
--- a/chunk-vector.scm
+++ b/chunk-vector.scm
@@ -43,11 +43,14 @@ SOFTWARE.
 	(define %chunk-size
 	  `(foreign-lambda unsigned-integer "dv_vector_chunk_size" chunk-vector))
 
+        (define (compose-name . args)
+          (inj (apply symbol-append (map strip-syntax args))))
+
 	`(begin
 
 	   ;; (make-<type>chunk-vector chunk-size [size-hint])
 	   ;; Create a new chunk vector with a chunk-size of /size/.
-	   (define (,(symbol-append 'make- (inj <prefix>) 'chunk-vector)
+	   (define (,(compose-name 'make- <prefix> 'chunk-vector)
 		    chunk-size #!optional (size-hint 64))
 	     (set-finalizer!
 	      ((foreign-lambda chunk-vector "dv_vector_new"
@@ -58,18 +61,18 @@ SOFTWARE.
 	   
 	   ;; (<type>vector-remove! vector index)
 	   ;; Removes a chunk from the vector using its /index/.
-	   (define ,(symbol-append (inj <prefix>) 'chunk-vector-remove!)
+	   (define ,(compose-name <prefix> 'chunk-vector-remove!)
 	     (foreign-lambda void "dv_vector_remove" chunk-vector unsigned-integer))
 
 	   ;; (<type>vector-set! vectror index value)
 	   ;; Changed the value of a chunk using its /index/.
-	   (define ,(symbol-append (inj <prefix>) 'chunk-vector-set!)
+	   (define ,(compose-name <prefix> 'chunk-vector-set!)
 	     (foreign-lambda void "dv_vector_change" chunk-vector 
 			     unsigned-integer ,(inj <vector-type>)))
 
 	   ;; (<type>vector-push! vector value)
 	   ;; Pushes a new chunk to the vector.
-	   (define (,(symbol-append (inj <prefix>) 'chunk-vector-push!)
+	   (define (,(compose-name <prefix> 'chunk-vector-push!)
 		    chunk-vector data)
 	     (let ((grown (make-u32vector 1)))
 	       ((foreign-lambda unsigned-integer "dv_vector_push" 
@@ -78,7 +81,7 @@ SOFTWARE.
 
 	   ;; (<type>vector-ref vector index)
 	   ;; Returns the data at /index/.
-	   (define (,(symbol-append (inj <prefix>) 'chunk-vector-ref)
+	   (define (,(compose-name <prefix> 'chunk-vector-ref)
 		    chunk-vector index)
 	     (let* ((chunk-size (,%chunk-size chunk-vector))
 		    (size (/ chunk-size (foreign-type-size ,(inj <type-string>))))
@@ -93,25 +96,25 @@ SOFTWARE.
 
 	   ;; (<type>vector-length vector)
 	   ;; Returns the number of chunks in the vector.
-	   (define ,(symbol-append (inj <prefix>) 'chunk-vector-length)
+	   (define ,(compose-name <prefix> 'chunk-vector-length)
 	     (foreign-lambda unsigned-integer "dv_vector_size" chunk-vector))
 
 	   ;; <type>vector->pointer
 	   ;; Returns a pointer to the dense foreign array where the data
 	   ;; is stored.
-	   (define ,(symbol-append (inj <prefix>) 'chunk-vector->pointer)
+	   (define ,(compose-name <prefix> 'chunk-vector->pointer)
 	     (foreign-lambda c-pointer "dv_vector_data" chunk-vector))
 
 	   ;; <type>vector-chunk-size
 	   ;; Returns a pointer to the dense foreign array where the data
 	   ;; is stored.
-	   (define ,(symbol-append (inj <prefix>) 'chunk-vector-chunk-size)
+	   (define ,(compose-name <prefix> 'chunk-vector-chunk-size)
 	     (foreign-lambda c-pointer "dv_vector_chunk_size" chunk-vector))
 
 	   ;; <type>vector-clear!
 	   ;; Returns a pointer to the dense foreign array where the data
 	   ;; is stored.
-	   (define ,(symbol-append (inj <prefix>) 'chunk-vector-clear!)
+	   (define ,(compose-name <prefix> 'chunk-vector-clear!)
 	     (foreign-lambda void "dv_vector_clear" chunk-vector))
 
 	   )) exp))))

--- a/chunk-vector.scm
+++ b/chunk-vector.scm
@@ -106,10 +106,9 @@ SOFTWARE.
 	     (foreign-lambda c-pointer "dv_vector_data" chunk-vector))
 
 	   ;; <type>vector-chunk-size
-	   ;; Returns a pointer to the dense foreign array where the data
-	   ;; is stored.
+	   ;; Returns the size of the chunk.
 	   (define ,(compose-name <prefix> 'chunk-vector-chunk-size)
-	     (foreign-lambda c-pointer "dv_vector_chunk_size" chunk-vector))
+	     (foreign-lambda unsigned-integer "dv_vector_chunk_size" chunk-vector))
 
 	   ;; <type>vector-clear!
 	   ;; Returns a pointer to the dense foreign array where the data


### PR DESCRIPTION
Hi Pluizer,

Here's a small fix for a bug in your egg, which was exposed by a recent commit in CHICKEN core. You can see that chunk-vector [started failing yesterday in the daily Salmonella run](https://salmonella-linux-x86-64.call-cc.org/master-debugbuild/gcc/linux/x86-64/2017/04/20/yesterday-diff/)

While at it, I also fixed these compiler warnings:

```
chunk-vector.c: In function ‘stub1483’:
chunk-vector.c:139:30: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 C_r=C_mpointer_or_false(&C_a,(void*)dv_vector_chunk_size(t0));
                              ^
chunk-vector.c: In function ‘stub1301’:
chunk-vector.c:230:30: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 C_r=C_mpointer_or_false(&C_a,(void*)dv_vector_chunk_size(t0));
                              ^
chunk-vector.c: In function ‘stub1117’:
chunk-vector.c:321:30: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 C_r=C_mpointer_or_false(&C_a,(void*)dv_vector_chunk_size(t0));
                              ^
chunk-vector.c: In function ‘stub933’:
chunk-vector.c:412:30: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 C_r=C_mpointer_or_false(&C_a,(void*)dv_vector_chunk_size(t0));
                              ^
chunk-vector.c: In function ‘stub749’:
chunk-vector.c:503:30: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 C_r=C_mpointer_or_false(&C_a,(void*)dv_vector_chunk_size(t0));
                              ^
chunk-vector.c: In function ‘stub565’:
chunk-vector.c:594:30: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 C_r=C_mpointer_or_false(&C_a,(void*)dv_vector_chunk_size(t0));
                              ^
chunk-vector.c: In function ‘stub381’:
chunk-vector.c:685:30: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 C_r=C_mpointer_or_false(&C_a,(void*)dv_vector_chunk_size(t0));
                              ^
chunk-vector.c: In function ‘stub197’:
chunk-vector.c:776:30: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 C_r=C_mpointer_or_false(&C_a,(void*)dv_vector_chunk_size(t0));
```